### PR TITLE
Housekeeping: Update development dependencies and test on Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby }}
     - name: Build and test
       run: |
         gem install bundler

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@fdcfbcf14ec9672f6f615cb9589a1bc5dd69d262
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,13 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.6', '3.0' ]
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        version: ${{ matrix.ruby }}
     - name: Build and test
       run: |
         gem install bundler

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
 
     steps:
     - uses: actions/checkout@master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,37 +6,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    diff-lcs (1.3)
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
     ed25519 (1.2.4)
-    method_source (0.8.2)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    method_source (1.0.0)
+    pry (0.14.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    slop (3.6.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   ed25519 (~> 1.2)
-  pry (~> 0.10)
-  rspec (~> 3.5)
-  rspec-mocks (~> 3.5)
+  pry (~> 0.14)
+  rspec (~> 3.10)
+  rspec-mocks (~> 3.10)
   ssh_data!
 
 BUNDLED WITH

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 require "ssh_data"
 require "ed25519"
 
+RSpec.configure do |config|
+  config.color_mode = :off
+end
+
 REPO_PATH    = File.expand_path(File.join(__FILE__, "..", ".."))
 FIXTURE_PATH = File.expand_path(File.join(REPO_PATH, "spec", "fixtures"))
 

--- a/ssh_data.gemspec
+++ b/ssh_data.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir["./lib/**/*.rb"] + ["./LICENSE.md"]
 
   s.add_development_dependency "ed25519", "~> 1.2"
-  s.add_development_dependency "pry", "~> 0.10"
-  s.add_development_dependency "rspec", "~> 3.5"
-  s.add_development_dependency "rspec-mocks", "~> 3.5"
+  s.add_development_dependency "pry", "~> 0.14"
+  s.add_development_dependency "rspec", "~> 3.10"
+  s.add_development_dependency "rspec-mocks", "~> 3.10"
 end


### PR DESCRIPTION
This does a few housekeeping tasks.

1. Update some development dependencies. They resolved deprecation warnings in newer rubies.
2. Test against Ruby 3.0 and replace `actions/setup-ruby` with `ruby/setup-ruby`. The former is deprecated. 

/cc @github/pse-architecture 