### PR TITLE
Support Ruby 3.1 and fix Q size to 160 bits

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
 
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@fdcfbcf14ec9672f6f615cb9589a1bc5dd69d262
+      uses: ruby/setup-ruby@f0971f0dd45a5cbb3f119f7db77cc58057c53530
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test

--- a/lib/ssh_data/private_key/dsa.rb
+++ b/lib/ssh_data/private_key/dsa.rb
@@ -7,7 +7,19 @@
       #
       # Returns a PublicKey::Base subclass instance.
       def self.generate
-        from_openssl(OpenSSL::PKey::DSA.generate(1024))
+        openssl_key =
+          if defined?(OpenSSL::PKey.generate_parameters)
+            dsa_parameters = OpenSSL::PKey.generate_parameters("DSA", {
+              dsa_paramgen_bits: 1024,
+              dsa_paramgen_q_bits: 160
+            })
+
+            OpenSSL::PKey.generate_key(dsa_parameters)
+          else
+            OpenSSL::PKey::DSA.generate(1024)
+          end
+
+        from_openssl(openssl_key)
       end
 
       # Import an openssl private key.

--- a/spec/private_key/dsa_spec.rb
+++ b/spec/private_key/dsa_spec.rb
@@ -17,6 +17,12 @@ describe SSHData::PrivateKey::DSA do
     }.not_to raise_error
   end
 
+  it "generates default parameters" do
+    key = described_class.generate
+    expect(key.q.num_bits).to eq(160)
+    expect(key.p.num_bits).to eq(1024)
+  end
+
   it "can sign messages" do
     expect(subject.public_key.verify(message, subject.sign(message))).to eq(true)
   end

--- a/spec/private_key/dsa_spec.rb
+++ b/spec/private_key/dsa_spec.rb
@@ -1,7 +1,7 @@
 require_relative "../spec_helper"
 
 describe SSHData::PrivateKey::DSA do
-  let(:private_key) { OpenSSL::PKey::DSA.generate(1024) }
+  let(:private_key) { SSHData::PrivateKey::DSA.generate.openssl }
   let(:public_key)  { private_key.public_key }
   let(:params)      { private_key.params }
   let(:message)     { "hello, world!" }

--- a/spec/public_key/dsa_spec.rb
+++ b/spec/public_key/dsa_spec.rb
@@ -1,7 +1,7 @@
 require_relative "../spec_helper"
 
 describe SSHData::PublicKey::DSA do
-  let(:private_key) { OpenSSL::PKey::DSA.generate(1024) }
+  let(:private_key) { SSHData::PrivateKey::DSA.generate.openssl }
   let(:public_key)  { private_key.public_key }
   let(:params)      { public_key.params }
 


### PR DESCRIPTION
This PR accomplishes two tasks:

1. Ruby 3.1 started shipping with ruby/openssl 3.0. This appears to have changed the default Q size value in DSA from 160 bits to 224.

    Given the following code:

    ```ruby
    require 'openssl'
    pkey = OpenSSL::PKey::DSA.generate(1024)
    puts pkey.params['q'].num_bits
    ```
    
    Ruby 3.1 will print 224, and Ruby <= 3.0 will print 160. Q directly impacts the size of the {r,s} values from the field. Since Q is no longer 160 bits (20 bytes), we can't encode the IEEE P1363 in a field-width format since it was assumed to be 20 bytes here:

    https://github.com/github/ssh_data/blob/e7c2b70c92d49670b34f6d3f5ecbfa13a83e17ba/lib/ssh_data/public_key/dsa.rb#L43-L45    

    This ensures that our generated DSA keys continue to use a 160-bit Q. It would be fairly simple to change the encoding / decoding to support any size Q, but given this is DSA which is pretty much obsolete, I saw no benefit to supporting 186-4-style signatures.

2. This adds CI protection for Ruby 3.1 by adding 3.1 to the matrix and updating the `setup-ruby` action to the minimum hash that supports Ruby 3.1.