### PR TITLE
Refactor signature spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    binding_ninja (0.2.3)
     coderay (1.1.3)
     diff-lcs (1.4.4)
     ed25519 (1.2.4)
     method_source (1.0.0)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    proc_to_ast (0.1.0)
+      coderay
+      parser
+      unparser
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -25,7 +33,16 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
+    rspec-parameterized (0.5.0)
+      binding_ninja (>= 0.2.3)
+      parser
+      proc_to_ast
+      rspec (>= 2.13, < 4)
+      unparser
     rspec-support (3.10.2)
+    unparser (0.6.5)
+      diff-lcs (~> 1.3)
+      parser (>= 3.1.0)
 
 PLATFORMS
   ruby
@@ -35,6 +52,7 @@ DEPENDENCIES
   pry (~> 0.14)
   rspec (~> 3.10)
   rspec-mocks (~> 3.10)
+  rspec-parameterized (~> 0.5)
   ssh_data!
 
 BUNDLED WITH

--- a/spec/signature_spec.rb
+++ b/spec/signature_spec.rb
@@ -1,74 +1,87 @@
 require_relative "./spec_helper"
 
 describe SSHData::Signature do
-  describe "end to end" do
-    it "can verify an Ed25519-SK git signature" do
-      message= "tree ed9f16d32a89e48289d9d4becc4ff47cbd11f58c\nparent 7c6364502eceecc87b276d8b49d8eb0ae96fd9e3\nauthor Kevin Jones <octocat@github.com> 1638815753 -0500\ncommitter Kevin Jones <octocat@github.com> 1638815828 -0500\n\ntest\n"
-      signature = <<~SIG
-      -----BEGIN SSH SIGNATURE-----
-      U1NIU0lHAAAAAQAAAEoAAAAac2stc3NoLWVkMjU1MTlAb3BlbnNzaC5jb20AAAAgnXUo8l
-      URoToCMzr+Rxeia/9yy+Rn+VwTTOqXdIgf7TUAAAAEc3NoOgAAAANnaXQAAAAAAAAABnNo
-      YTUxMgAAAGcAAAAac2stc3NoLWVkMjU1MTlAb3BlbnNzaC5jb20AAABAud+P+aC7yCEcgy
-      smyAyN5iokI0T+dKuhl7Ml7XB/wPBlefSamMXoHE7k3BbAXBNXJQH0TtHo/aX0gZxLy44D
-      DgUAAAAG
-      -----END SSH SIGNATURE-----
-      SIG
+  def read_fixture_file(name)
+    fixture_file_path = File.join("spec/fixtures/signatures", name)
+    File.read(fixture_file_path)
+  end
 
-      subject = described_class.parse_pem(signature)
-      expect(subject.verify(message)).to be(true)
+  let(:name) { File.basename(path) }
+  let(:signature) { File.read(path) }
+  let(:message) { read_fixture_file("message") }
+
+  subject { described_class.parse_pem(signature) }
+
+  describe "end to end" do
+    context "with an Ed25519-SK git signature" do
+      let(:message) { "tree ed9f16d32a89e48289d9d4becc4ff47cbd11f58c\nparent 7c6364502eceecc87b276d8b49d8eb0ae96fd9e3\nauthor Kevin Jones <octocat@github.com> 1638815753 -0500\ncommitter Kevin Jones <octocat@github.com> 1638815828 -0500\n\ntest\n" }
+
+      let(:signature) do
+        <<~SIG
+          -----BEGIN SSH SIGNATURE-----
+          U1NIU0lHAAAAAQAAAEoAAAAac2stc3NoLWVkMjU1MTlAb3BlbnNzaC5jb20AAAAgnXUo8l
+          URoToCMzr+Rxeia/9yy+Rn+VwTTOqXdIgf7TUAAAAEc3NoOgAAAANnaXQAAAAAAAAABnNo
+          YTUxMgAAAGcAAAAac2stc3NoLWVkMjU1MTlAb3BlbnNzaC5jb20AAABAud+P+aC7yCEcgy
+          smyAyN5iokI0T+dKuhl7Ml7XB/wPBlefSamMXoHE7k3BbAXBNXJQH0TtHo/aX0gZxLy44D
+          DgUAAAAG
+          -----END SSH SIGNATURE-----
+        SIG
+      end
+
+
+      it "verifies the message" do
+        expect(subject.verify(message)).to be(true)
+      end
     end
 
-    it "can verify an RSA git signature" do
-      message = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\nparent 339ca5fd2a41e29236ea793772308bb054b9d81b\nauthor Kevin Jones <vcsjones@github.com> 1637774236 -0500\ncommitter Kevin Jones <vcsjones@github.com> 1637774236 -0500\n\nWHAT\n"
-      signature = <<~SIG
-        -----BEGIN SSH SIGNATURE-----
-        U1NIU0lHAAAAAQAAAZcAAAAHc3NoLXJzYQAAAAMBAAEAAAGBANEwkDjsYE02vY+bTFXAL9
-        xaGDFRwpAYutfhl7eL1Qn6dziGnokqMz1FnwPbRkPUOtdwXbojK0W45DS8rODLhvwyEJjj
-        sY2L9pKX/6hKDgb1RjtNAv57OHnfW3qyZWM/Nyd5js9K+43JN1ECoWCTVqtAaJcyfNXY8Y
-        FeR6x5ARkBZf+tgPA2+xIdmDf0jxyZ+hr6LRnE6/N9WsrCURnwx3u8XE8kusudBXDD4XKp
-        F/AqptHwi6OML+9kRQmyXXYs1dvPaJi4TGAGlPPD7mQaWT9fsKXJZa3jl6ckzq6D7SDDPh
-        CF2e/ZpzIJuusMQrx2snhKgKYh+G4WS/FpLcan+HG+/bv91lzNBXufJSLs5oo0B13L6ZaK
-        CJMkzG4zo/evDiomkXv9Fg8f2bIw2Ayh56Cd4Dcc2MYfziG3yLiVQrDu2eCTuILYzYdcFw
-        hzxkS8V6Ep+9U4ct0Zt+hTpyloSnQ7AEX/FKHAT7xdQxVoYaY7cVRyOWMROQ6ArxiNbPnk
-        JQAAAANnaXQAAAAAAAAABnNoYTUxMgAAAZQAAAAMcnNhLXNoYTItNTEyAAABgKE+f+H3D1
-        +kgPGi1TulPivysng0PIUthoVHSpJ5OKd2VrbdiH5B/XK1DmhpxCFVy6WAKD/x7a6Qpjd2
-        VSVsKdtJeBLfniTWB/LJQD/5miEVBG10F9V5EaEl4uRiQrTTGEAznBg3k0yIUVBdWWjoJh
-        5dLw+NQNWf9yw+/hNbtcCjkMeeZLvLwZNhsFxhRiIi5cy5m6O/eSSekaXe4sj0HxmuSIwh
-        8bFRlU+JQwmJ5P1tsnyhwaSSs5qnJ0MXiDeLD5MOt9PGDJhnNarMqYkA61slhhq1XkQu1E
-        FXdurNLkKaTpViSlFXqjFGXgoyB8yWB9DuqoZm69xGtCh1TmKkyE3M2R6hqXTqc90Szkxr
-        POr3R0OsJrYu1VOc//AKz7AHp1DGHOTNZkpfYVzm76wrkPS9LMVieZkelcr75/az+w6kev
-        qi1HNSYwD+pWej8+oCw6jri/ulGHDYyARR4ZSIR2AgBP5QZ0B0aLNr5F9ufbJvkGEpUvQH
-        rfqicASU/vCBEQ==
-        -----END SSH SIGNATURE-----
-      SIG
+    context 'with an RSA git signature' do
+      let(:message) { "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\nparent 339ca5fd2a41e29236ea793772308bb054b9d81b\nauthor Kevin Jones <vcsjones@github.com> 1637774236 -0500\ncommitter Kevin Jones <vcsjones@github.com> 1637774236 -0500\n\nWHAT\n" }
 
-      subject = described_class.parse_pem(signature)
-      expect(subject.verify(message)).to be(true)
+      let(:signature) do
+        <<~SIG
+          -----BEGIN SSH SIGNATURE-----
+          U1NIU0lHAAAAAQAAAZcAAAAHc3NoLXJzYQAAAAMBAAEAAAGBANEwkDjsYE02vY+bTFXAL9
+          xaGDFRwpAYutfhl7eL1Qn6dziGnokqMz1FnwPbRkPUOtdwXbojK0W45DS8rODLhvwyEJjj
+          sY2L9pKX/6hKDgb1RjtNAv57OHnfW3qyZWM/Nyd5js9K+43JN1ECoWCTVqtAaJcyfNXY8Y
+          FeR6x5ARkBZf+tgPA2+xIdmDf0jxyZ+hr6LRnE6/N9WsrCURnwx3u8XE8kusudBXDD4XKp
+          F/AqptHwi6OML+9kRQmyXXYs1dvPaJi4TGAGlPPD7mQaWT9fsKXJZa3jl6ckzq6D7SDDPh
+          CF2e/ZpzIJuusMQrx2snhKgKYh+G4WS/FpLcan+HG+/bv91lzNBXufJSLs5oo0B13L6ZaK
+          CJMkzG4zo/evDiomkXv9Fg8f2bIw2Ayh56Cd4Dcc2MYfziG3yLiVQrDu2eCTuILYzYdcFw
+          hzxkS8V6Ep+9U4ct0Zt+hTpyloSnQ7AEX/FKHAT7xdQxVoYaY7cVRyOWMROQ6ArxiNbPnk
+          JQAAAANnaXQAAAAAAAAABnNoYTUxMgAAAZQAAAAMcnNhLXNoYTItNTEyAAABgKE+f+H3D1
+          +kgPGi1TulPivysng0PIUthoVHSpJ5OKd2VrbdiH5B/XK1DmhpxCFVy6WAKD/x7a6Qpjd2
+          VSVsKdtJeBLfniTWB/LJQD/5miEVBG10F9V5EaEl4uRiQrTTGEAznBg3k0yIUVBdWWjoJh
+          5dLw+NQNWf9yw+/hNbtcCjkMeeZLvLwZNhsFxhRiIi5cy5m6O/eSSekaXe4sj0HxmuSIwh
+          8bFRlU+JQwmJ5P1tsnyhwaSSs5qnJ0MXiDeLD5MOt9PGDJhnNarMqYkA61slhhq1XkQu1E
+          FXdurNLkKaTpViSlFXqjFGXgoyB8yWB9DuqoZm69xGtCh1TmKkyE3M2R6hqXTqc90Szkxr
+          POr3R0OsJrYu1VOc//AKz7AHp1DGHOTNZkpfYVzm76wrkPS9LMVieZkelcr75/az+w6kev
+          qi1HNSYwD+pWej8+oCw6jri/ulGHDYyARR4ZSIR2AgBP5QZ0B0aLNr5F9ufbJvkGEpUvQH
+          rfqicASU/vCBEQ==
+          -----END SSH SIGNATURE-----
+        SIG
+      end
+
+      it "verifies the message" do
+        expect(subject.verify(message)).to be(true)
+      end
     end
   end
 
   describe "#verify" do
+    where(:path) { Dir["spec/fixtures/signatures/message.*no-options-individual.sig"] }
 
-    Dir["spec/fixtures/signatures/message.*no-options-individual.sig"].each do |path|
-      name = File.basename(path)
-
-      describe name do
-        let(:signature) { File.read(path) }
-        let(:data) { File.read("spec/fixtures/signatures/message") }
-
+    with_them do
+      describe do
         it "verifies with data" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data)).to be(true)
+          expect(subject.verify(message)).to be(true)
         end
 
         it "does not verify with tampered data" do
-          bad_data = data + "bad"
-          subject = described_class.parse_pem(signature)
+          bad_data = message + "bad"
           expect(subject.verify(bad_data)).to be(false)
         end
 
         it "parses correctly" do
-          subject = described_class.parse_pem(signature)
           expect(subject.sigversion).to eq(1)
           expect(subject.namespace).to eq("file")
           expect(subject.reserved).to be_empty
@@ -80,75 +93,57 @@ describe SSHData::Signature do
   end
 
   describe "#verify security keys" do
-    Dir["spec/fixtures/signatures/message.*-sk-*no-options-individual.sig"].each do |path|
-      name = File.basename(path)
+    where(:path) { Dir["spec/fixtures/signatures/message.*-sk-*no-options-individual.sig"] }
 
-      describe name do
-        let(:signature) { File.read(path) }
-        let(:data) { File.read("spec/fixtures/signatures/message") }
-
+    with_them do
+      describe do
         it "does not verify if user verification is required" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data, user_verification_required: true)).to be(false)
+          expect(subject.verify(message, user_verification_required: true)).to be(false)
         end
       end
     end
   end
 
   describe "#verify no-touch" do
-    Dir["spec/fixtures/signatures/message.*no-touch-required-individual.sig"].each do |path|
-      name = File.basename(path)
+    where(:path) { Dir["spec/fixtures/signatures/message.*no-touch-required-individual.sig"] }
 
-      describe name do
-        let(:signature) { File.read(path) }
-        let(:data) { File.read("spec/fixtures/signatures/message") }
-
+    with_them do
+      describe do
         it "verifies with data" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data, user_presence_required: false)).to be(true)
+          expect(subject.verify(message, user_presence_required: false)).to be(true)
         end
 
         it "does not verify with tampered data" do
-          bad_data = data + "bad"
-          subject = described_class.parse_pem(signature)
+          bad_data = message + "bad"
           expect(subject.verify(bad_data, user_presence_required: false)).to be(false)
         end
 
         it "does not verify with user presence" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data, user_presence_required: true)).to be(false)
+          expect(subject.verify(message, user_presence_required: true)).to be(false)
         end
 
         it "does not verify with user presence by default" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data)).to be(false)
+          expect(subject.verify(message)).to be(false)
         end
 
         it "errors on unknown verify options" do
-          subject = described_class.parse_pem(signature)
-          expect { subject.verify(data, potato: :no) }.to raise_error(SSHData::UnsupportedError)
+          expect { subject.verify(message, potato: :no) }.to raise_error(SSHData::UnsupportedError)
         end
       end
     end
   end
 
   describe "#verify verify-required" do
+    where(:path) { Dir["spec/fixtures/signatures/message.*verify-required-individual.sig"] }
 
-    Dir["spec/fixtures/signatures/message.*verify-required-individual.sig"].each do |path|
-      name = File.basename(path)
-
-      describe name do
-        let(:signature) { File.read(path) }
-        let(:data) { File.read("spec/fixtures/signatures/message") }
-
+    with_them do
+      describe do
         it "verifies with data" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data, user_verification_required: true)).to be(true)
+          expect(subject.verify(message, user_verification_required: true)).to be(true)
         end
 
         it "does not verify with tampered data" do
-          bad_data = data + "bad"
-          subject = described_class.parse_pem(signature)
+          bad_data = message + "bad"
           expect(subject.verify(bad_data, user_verification_required: true)).to be(false)
         end
       end
@@ -156,16 +151,11 @@ describe SSHData::Signature do
   end
 
   describe "#verify certificates" do
+    where(:path) { Dir["spec/fixtures/signatures/message.*no-options-certificate.sig"] }
 
-    Dir["spec/fixtures/signatures/message.*no-options-certificate.sig"].each do |path|
-      name = File.basename(path)
-
-      describe name do
-        let(:signature) { File.read(path) }
-        let(:data) { File.read("spec/fixtures/signatures/message") }
-
+    with_them do
+      describe do
         it "parses correctly" do
-          subject = described_class.parse_pem(signature)
           expect(subject.sigversion).to eq(1)
           expect(subject.namespace).to eq("file")
           expect(subject.reserved).to be_empty
@@ -174,18 +164,14 @@ describe SSHData::Signature do
         end
 
         it "verifies with data" do
-          subject = described_class.parse_pem(signature)
-          expect(subject.verify(data)).to be(true)
+          expect(subject.verify(message)).to be(true)
         end
 
         it "does not verify with tampered data" do
-          bad_data = data + "bad"
-          subject = described_class.parse_pem(signature)
+          bad_data = message + "bad"
           expect(subject.verify(bad_data)).to be(false)
         end
-
       end
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "ssh_data"
 require "ed25519"
+require "rspec-parameterized"
 
 RSpec.configure do |config|
   config.color_mode = :off

--- a/ssh_data.gemspec
+++ b/ssh_data.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ed25519", "~> 1.2"
   s.add_development_dependency "pry", "~> 0.14"
   s.add_development_dependency "rspec", "~> 3.10"
+  s.add_development_dependency "rspec-parameterized", "~> 0.5"
   s.add_development_dependency "rspec-mocks", "~> 3.10"
 end


### PR DESCRIPTION
Make use of `let` and `where` (from `rspec-parameterized`) to avoid having to do variable declarations inside each test case. 