### PR TITLE
Add Ruby 3.2 to test matrix and support OpenSSL 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
 
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@f0971f0dd45a5cbb3f119f7db77cc58057c53530
+      uses: ruby/setup-ruby@ad718faf7af4b26fef9165e2d675890b51901e6c
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test

--- a/lib/ssh_data/private_key/ecdsa.rb
+++ b/lib/ssh_data/private_key/ecdsa.rb
@@ -13,7 +13,7 @@ module SSHData
         openssl_curve = PublicKey::ECDSA::OPENSSL_CURVE_NAME_FOR_CURVE[curve]
         raise AlgorithmError, "unknown curve: #{curve}" if openssl_curve.nil?
 
-        openssl_key = OpenSSL::PKey::EC.new(openssl_curve).tap(&:generate_key)
+        openssl_key = OpenSSL::PKey::EC.generate(openssl_curve)
         from_openssl(openssl_key)
       end
 

--- a/spec/private_key/ecdsa_spec.rb
+++ b/spec/private_key/ecdsa_spec.rb
@@ -21,8 +21,8 @@ describe SSHData::PrivateKey::ECDSA do
     describe openssl_curve do
       let(:algo) { "ecdsa-sha2-#{ssh_curve}" }
 
-      let(:private_key) { OpenSSL::PKey::EC.new(openssl_curve).tap(&:generate_key) }
-      let(:public_key)  { OpenSSL::PKey::EC.new(private_key.to_der).tap { |k| k.private_key = nil } }
+      let(:private_key) { OpenSSL::PKey::EC.generate(openssl_curve) }
+      let(:public_key)  { ec_private_to_public(private_key) }
       let(:comment)     { "asdf" }
       let(:message)     { "hello, world!" }
 

--- a/spec/public_key/ecdsa_spec.rb
+++ b/spec/public_key/ecdsa_spec.rb
@@ -37,8 +37,8 @@ describe SSHData::PublicKey::ECDSA do
     describe openssl_curve do
       let(:algo) { "ecdsa-sha2-#{ssh_curve}" }
 
-      let(:private_key) { OpenSSL::PKey::EC.new(openssl_curve).tap(&:generate_key) }
-      let(:public_key)  { OpenSSL::PKey::EC.new(private_key.to_der).tap { |k| k.private_key = nil } }
+      let(:private_key) { OpenSSL::PKey::EC.generate(openssl_curve) }
+      let(:public_key)  { ec_private_to_public(private_key) }
 
       let(:msg)         { "hello, world!" }
       let(:digest)      { described_class::DIGEST_FOR_CURVE[ssh_curve].new }
@@ -63,7 +63,7 @@ describe SSHData::PublicKey::ECDSA do
       end
 
       it "isnt equal to keys with different params" do
-        other_key = OpenSSL::PKey::EC.new(openssl_curve).tap(&:generate_key)
+        other_key = OpenSSL::PKey::EC.generate(openssl_curve)
 
         expect(subject).not_to eq(described_class.new(
           algo: algo,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,14 @@ def ssh_keygen_fingerprint(name, algo, priv: false)
   out = `ssh-keygen #{"-e" if priv} -E #{algo} -l -f #{File.join(FIXTURE_PATH, name)}`
   out.split(":", 2).last.split(" ").first
 end
+
+def ec_private_to_public(private_key)
+  algorithm_identifier = OpenSSL::ASN1::Sequence.new([
+    OpenSSL::ASN1::ObjectId.new("id-ecPublicKey"),
+    OpenSSL::ASN1::ObjectId.new(private_key.group.curve_name)
+  ])
+
+  subject_public_key = OpenSSL::ASN1::BitString.new(private_key.public_key.to_bn.to_s(2))
+  spki = OpenSSL::ASN1::Sequence.new([algorithm_identifier, subject_public_key])
+  OpenSSL::PKey::EC.new(spki.to_der)
+end


### PR DESCRIPTION
This adds support for Ruby 3.2 and adds it to our CI matrix.

This also addresses some usages of `OpenSSL` that don't work with OpenSSL 3.0, which the latest version of Ubuntu does.

The gist of it is that PKey instances are immutable. So that means places where we were doing `new(curve).tap(&:generate_key)` we now just want to use `generate`. This is the only change to live "functional" code.

The immutability was more of a challenge for our tests where we want to convert a private key to just a public one. This is surprisingly difficult to do with the `private_key` and `public_key` property setters not available. In that case, we roundtrip the private key through a SubjectPublicKeyInfo, which OpenSSL is capable of using. Since this is just test code, it's reasonable enough.