### PR TITLE
Change documentation return type of PrivateKey::RSA.from_openssl

### DIFF
--- a/lib/ssh_data/private_key/rsa.rb
+++ b/lib/ssh_data/private_key/rsa.rb
@@ -21,9 +21,9 @@ module SSHData
 
       # Import an openssl private key.
       #
-      # key - An OpenSSL::PKey::DSA instance.
+      # key - An OpenSSL::PKey::RSA instance.
       #
-      # Returns a DSA instance.
+      # Returns a RSA instance.
       def self.from_openssl(key)
         new(
           algo: PublicKey::ALGO_RSA,


### PR DESCRIPTION
This PR updates the documentation comment to return an `OpenSSL::PKey::RSA` instance instead of `OpenSSL::PKey::DSA`