### PR TITLE
Updates for ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test
       run: |
-        gem install bundler
         bundle install --jobs 4 --retry 3
         find ./spec/fixtures -type f -exec chmod 600 -- {} +
         bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@ad718faf7af4b26fef9165e2d675890b51901e6c
+      uses: ruby/setup-ruby@b256bd96bb4867e7d23e92e087d9bb697270b725
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,47 +2,58 @@ PATH
   remote: .
   specs:
     ssh_data (1.3.0)
+      base64 (~> 0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    binding_ninja (0.2.3)
+    base64 (0.2.0)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     coderay (1.1.3)
-    diff-lcs (1.4.4)
-    ed25519 (1.2.4)
+    debug_inspector (1.2.0)
+    diff-lcs (1.5.0)
+    ed25519 (1.3.0)
     method_source (1.0.0)
-    parser (3.1.2.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
     proc_to_ast (0.1.0)
       coderay
       parser
       unparser
-    pry (0.14.0)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    racc (1.7.3)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-parameterized (0.5.0)
-      binding_ninja (>= 0.2.3)
+      rspec-support (~> 3.12.0)
+    rspec-parameterized (1.0.0)
+      rspec-parameterized-core (< 2)
+      rspec-parameterized-table_syntax (< 2)
+    rspec-parameterized-core (1.0.0)
       parser
       proc_to_ast
       rspec (>= 2.13, < 4)
       unparser
-    rspec-support (3.10.2)
-    unparser (0.6.5)
+    rspec-parameterized-table_syntax (1.0.1)
+      binding_of_caller
+      rspec-parameterized-core (< 2)
+    rspec-support (3.12.1)
+    unparser (0.6.10)
       diff-lcs (~> 1.3)
-      parser (>= 3.1.0)
+      parser (>= 3.2.2.4)
 
 PLATFORMS
   ruby
@@ -52,8 +63,8 @@ DEPENDENCIES
   pry (~> 0.14)
   rspec (~> 3.10)
   rspec-mocks (~> 3.10)
-  rspec-parameterized (~> 0.5)
+  rspec-parameterized (~> 1.0)
   ssh_data!
 
 BUNDLED WITH
-   2.1.4
+   2.4.22

--- a/ssh_data.gemspec
+++ b/ssh_data.gemspec
@@ -12,9 +12,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3"
   s.files = Dir["./lib/**/*.rb"] + ["./LICENSE.md"]
 
+  s.add_dependency "base64", "~> 0.1"
+
   s.add_development_dependency "ed25519", "~> 1.2"
   s.add_development_dependency "pry", "~> 0.14"
   s.add_development_dependency "rspec", "~> 3.10"
-  s.add_development_dependency "rspec-parameterized", "~> 0.5"
+  s.add_development_dependency "rspec-parameterized", "~> 1.0"
   s.add_development_dependency "rspec-mocks", "~> 3.10"
 end


### PR DESCRIPTION
* Update dependencies. All dependencies are development dependencies that were updated.
* Add an explicit dependency on the `base64` gem. See ["Standard library updates"](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) in the release notes for why.
* Add ruby 3.3 to the test matrix. Update `setup-ruby` to the 3.3.0 tag, referenced by hash.
    * Remove the `gem install bundler` step. This is done by `setup-ruby` and may install a version of bundler that does not work on older ruby versions.