### PR TITLE
Skip tests where ssh-keygen cannot create a fingerprint for DSA/DSS keys.

### DIFF
--- a/spec/private_key_spec.rb
+++ b/spec/private_key_spec.rb
@@ -15,10 +15,12 @@ describe SSHData::PrivateKey do
       end
 
       it "generates a MD5 fingerprint matching ssh-keygen" do
+        skip "Fingerprint not available" if md5_fpr.nil?
         expect(subject.public_key.fingerprint(md5: true)).to eq(md5_fpr)
       end
 
       it "generates a SHA256 fingerprint matching ssh-keygen" do
+        skip "Fingerprint not available" if sha256_fpr.nil?
         expect(subject.public_key.fingerprint).to eq(sha256_fpr)
       end
 

--- a/spec/public_key_spec.rb
+++ b/spec/public_key_spec.rb
@@ -13,15 +13,19 @@ describe SSHData::PublicKey do
     describe name do
       let(:openssh) { fixture(name).strip }
       let(:comment) { SSHData.key_parts(openssh).last }
+      let(:sha256_fpr) { ssh_keygen_fingerprint(name, :sha256) }
+      let(:md5_fpr)    { ssh_keygen_fingerprint(name, :md5) }
 
       subject { described_class.parse_openssh(openssh) }
 
       it "generates a MD5 fingerprint matching ssh-keygen" do
-        expect(subject.fingerprint(md5: true)).to eq(ssh_keygen_fingerprint(name, :md5))
+        skip "Fingerprint not available" if md5_fpr.nil?
+        expect(subject.fingerprint(md5: true)).to eq(md5_fpr)
       end
 
       it "generates a SHA256 fingerprint matching ssh-keygen" do
-        expect(subject.fingerprint).to eq(ssh_keygen_fingerprint(name, :sha256))
+        skip "Fingerprint not available" if sha256_fpr.nil?
+        expect(subject.fingerprint).to eq(sha256_fpr)
       end
 
       it "can re-encode back into authorized_keys format" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "ssh_data"
 require "ed25519"
 require "rspec-parameterized"
+require "open3"
 
 RSpec.configure do |config|
   config.color_mode = :off
@@ -21,7 +22,9 @@ def fixture(name, binary: false, pem: false)
 end
 
 def ssh_keygen_fingerprint(name, algo, priv: false)
-  out = `ssh-keygen #{"-e" if priv} -E #{algo} -l -f #{File.join(FIXTURE_PATH, name)}`
+  out, * = Open3.capture3("ssh-keygen #{'-e' if priv} -E #{algo} -l -f #{File.join(FIXTURE_PATH, name)}")
+
+  return nil if out.strip.empty?
   out.split(":", 2).last.split(" ").first
 end
 


### PR DESCRIPTION
Newer versions of OpenSSH no longer support the legacy algorithm DSA/DSS. When ssh-keygen is used to get the fingerprint for a DSA key, those OpenSSH versions will fail. When ssh-keygen is unable to generate a fingerprint, we will skip the test.

Long term we should probably deprecate and remove DSA/DSS in the same steps as OpenSSH, but this gets our tests back to green as a first step.