### PR TITLE
[Chore]: Update workflow to run on ruby 3.4, and drop EOL ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@b256bd96bb4867e7d23e92e087d9bb697270b725
+      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ssh_data (1.3.0)
+    ssh_data (2.0.0)
       base64 (~> 0.1)
 
 GEM

--- a/lib/ssh_data/version.rb
+++ b/lib/ssh_data/version.rb
@@ -1,3 +1,3 @@
 module SSHData
-  VERSION = "1.3.0"
+  VERSION = "2.0.0"
 end

--- a/ssh_data.gemspec
+++ b/ssh_data.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/github/ssh_data"
   s.authors = ["mastahyeti"]
   s.email = "opensource+ssh_data@github.com"
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 3.1"
   s.files = Dir["./lib/**/*.rb"] + ["./LICENSE.md"]
 
   s.add_dependency "base64", "~> 0.1"


### PR DESCRIPTION
1. This adds ruby 3.4 to our run matrix.
2. This drops 2.7 and 3.0. They are EOL.
3. Update the `ruby/setup-ruby` action with a new pinned SHA that supports Ruby 3.4.x.
4. Increase the minimum ruby version, and bump the gem version to 2.0.