### PR TITLE
Add Ruby 4.0 to test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0.0-preview2' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0.0-preview2' ]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+      uses: ruby/setup-ruby@d697be2f83c6234b20877c3b5eac7a7f342f0d0c
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test


### PR DESCRIPTION
This add ruby 4.0 to CI. 4.0 is currently preview right now, but we should get validation in early.